### PR TITLE
Update namespace usage in plugin file updates to include views directory

### DIFF
--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -195,7 +195,7 @@ func updatePluginFiles(config *config.PluginConfig) error {
 		{"namespace WordPressPluginBoilerplate", fmt.Sprintf("namespace %s", config.Namespace), []string{config.PluginFileName, "plugin.php"}, false},
 		{"use WordPressPluginBoilerplate", fmt.Sprintf("use %s", config.Namespace), []string{config.PluginFileName, "plugin.php"}, false},
 		{"namespace WordPressPluginBoilerplate", fmt.Sprintf("namespace %s", config.Namespace), []string{"includes"}, true},
-		{"use WordPressPluginBoilerplate", fmt.Sprintf("use %s", config.Namespace), []string{"includes"}, true},
+		{"use WordPressPluginBoilerplate", fmt.Sprintf("use %s", config.Namespace), []string{"includes", "views"}, true},
 		{"WordPressPluginBoilerplate", config.Namespace, []string{"includes"}, true},
 
 		// Database namespace replacements

--- a/internal/commands/create.go
+++ b/internal/commands/create.go
@@ -196,7 +196,7 @@ func updatePluginFiles(config *config.PluginConfig) error {
 		{"use WordPressPluginBoilerplate", fmt.Sprintf("use %s", config.Namespace), []string{config.PluginFileName, "plugin.php"}, false},
 		{"namespace WordPressPluginBoilerplate", fmt.Sprintf("namespace %s", config.Namespace), []string{"includes"}, true},
 		{"use WordPressPluginBoilerplate", fmt.Sprintf("use %s", config.Namespace), []string{"includes", "views"}, true},
-		{"WordPressPluginBoilerplate", config.Namespace, []string{"includes"}, true},
+		{"WordPressPluginBoilerplate", config.Namespace, []string{"includes", "views"}, true},
 
 		// Database namespace replacements
 		{"namespace WordPressPluginBoilerplate", fmt.Sprintf("namespace %s", config.Namespace), []string{"database"}, true},


### PR DESCRIPTION
Fix when replacing the namespaces, the views directory is not included.